### PR TITLE
Fix casing of redirectURL

### DIFF
--- a/Vcr.HttpRecorder/Repositories/HAR/Response.cs
+++ b/Vcr.HttpRecorder/Repositories/HAR/Response.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Net;
 using System.Net.Http;
+using System.Text.Json.Serialization;
 
 namespace Vcr.HttpRecorder.Repositories.HAR
 {
@@ -71,10 +72,7 @@ namespace Vcr.HttpRecorder.Repositories.HAR
         /// <summary>
         /// Gets or sets the redirection target URL from the Location response header.
         /// </summary>
-        /// <remarks>
-        /// This property must have the <c>URL</c> part in uppercase to observe the <a href="https://w3c.github.io/web-performance/specs/HAR/Overview.html">HAR specification</a>.
-        /// Renaming this property to <c>RedirectUrl</c> could break tools implementing the HAR specification.
-        /// </remarks>
+        [JsonPropertyName("redirectURL")]
         public string RedirectUrl { get; set; } = string.Empty;
 
         /// <summary>


### PR DESCRIPTION
GitHub Issue: https://github.com/nventive/HttpRecorder/pull/10

## Proposed Changes

- Bug fix

## What is the current behavior?

The redirect URL is serialized as `redirectUrl`

## What is the new behavior?

The redirect URL is serialized as `redirectURL` (URL all uppercased)

## Checklist

Please check if your PR fulfills the following requirements:

- [x] Documentation has been added/updated (not needed, this is a bug fix)
- [ ] Automated Unit / Integration tests for the changes have been added/updated (not sure what would be the best way to add a test for this)
- [x] Contains **NO** breaking changes
- [x] Updated the Changelog (there is no more CHANGELOG.md 🤔)
- [x] Associated with an issue

